### PR TITLE
feat: porting support for custom models, drop of support for `v1/completions` form translator

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -214,13 +214,7 @@ declare namespace Bob {
 
   // https://ripperhe.gitee.io/bob/#/plugin/api/option
   type Option = {
-    apiKeys: string;
-    apiUrl: string;
-    customSystemPrompt: string;
-    customUserPrompt: string;
-    deploymentName: string;
-    model: string;
-    polishingMode: "simplicity" | "detailed";
+    [propName: string]: string;
   };
 
 

--- a/src/info.json
+++ b/src/info.json
@@ -25,9 +25,20 @@
       "identifier": "deploymentName",
       "type": "text",
       "title": "Dep. Name",
-      "desc": "可选项。此值为在部署模型时为部署选择的自定义名称，可在 Azure 门户中的 “资源管理“＞“部署“下查看",
+      "desc": "可选项。此值为在部署 Azure 模型时为部署选择的自定义名称，可在 Azure 门户中的 “资源管理”＞“部署” 下查看",
       "textConfig": {
         "type": "visible"
+      }
+    },
+    {
+      "identifier": "apiVersion",
+      "type": "text",
+      "title": "API Version",
+      "defaultValue": "2023-03-15-preview",
+      "desc": "可选项。此值为在使用 Azure 模型时采用的 Chat completions API 版本，不支持 2023-03-15-preview 之前的版本",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "2023-03-15-preview"
       }
     },
     {
@@ -47,6 +58,10 @@
       "title": "模型",
       "defaultValue": "gpt-3.5-turbo-0613",
       "menuValues": [
+        {
+          "title": "custom",
+          "value": "custom"
+        },
         {
           "title": "gpt-3.5-turbo-0613 (recommended)",
           "value": "gpt-3.5-turbo-0613"
@@ -86,16 +101,18 @@
         {
           "title": "gpt-4-32k-0613",
           "value": "gpt-4-32k-0613"
-        },
-        {
-          "title": "text-davinci-003",
-          "value": "text-davinci-003"
-        },
-        {
-          "title": "text-davinci-002",
-          "value": "text-davinci-002"
         }
       ]
+    },
+    {
+      "identifier": "customModel",
+      "type": "text",
+      "title": "自定义模型",
+      "desc": "可选项。当 Model 选择为 custom 时，此项为必填项。请填写有效的模型名称",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "gpt-3.5-turbo"
+      }
     },
     {
       "identifier": "customSystemPrompt",


### PR DESCRIPTION
In issue #31, I ported the support for custom models from translator (see commit [a3b9d39](https://github.com/openai-translator/bob-plugin-openai-translator/commit/a3b9d3957d4c834fac897c5e2f39741cccde2861)) in addition of fixed the `polishingMode` type. Also, I updated the default API version for Azure as detailed in commit [a7dcc7e](https://github.com/openai-translator/bob-plugin-openai-translator/commit/a7dcc7e7594699ada1cab32af0a222536347f3d6). 

Testing with model `gpt-4-1106-preview` confirmed that error messages display correctly even when no custom model is specified.


Added options of custom model:
![Added options of custom model](https://github.com/openai-translator/bob-plugin-openai-polisher/assets/15743306/23c76b91-46e5-4d28-aec6-39545448065c)

Error message without custom model set:
![Error message without custom model set](https://github.com/openai-translator/bob-plugin-openai-polisher/assets/15743306/5d3a7899-70a6-4624-bee3-b415824406ae)
